### PR TITLE
Adding new features

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -10,8 +10,19 @@ css: >
     animation-duration: 0s !important;
     transition-duration: 0s !important;
   }
+sitemap:
+  path: '/sitemap.json'
+  ignore:
+    - 'parents.pdf'
 urls:
    - url: '/'
+   - url: '/'
+     name: 'bounce'
+     css: >
+      .bounce-modal {
+        display: block;
+      }
+   - url: '/mentor-her/'
      css: >
       .section-tall-wrapper {
         min-height: auto !important;

--- a/index.js
+++ b/index.js
@@ -9,9 +9,12 @@ const domain = args[1];
 (async () => {
   try {
     const config = await fileParser(yaml, { domain });
+    const urlsNumber = config.urls.length;
+    const devicesNumber = Object.keys(config.devices).length;
+    const total = urlsNumber * devicesNumber;
 
-    console.log(`Hitting "${config.domain}" for ${config.urls.length} URL(s) with ${Object.keys(config.devices).length} device(s)`);
-    urlProcess(config);
+    console.log(`Hitting "${config.domain}" for ${urlsNumber} URL(s) with ${devicesNumber} device(s). ${total} images expected.`);
+    await urlProcess(config);
   } catch (e) {
     console.log(e);
     process.exit(1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,6 +294,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node-fetch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.0.0.tgz",
+      "integrity": "sha1-mCu6Q+zU8pIqKcwYamu7C7c/y6Y="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "js-yaml": "^3.10.0",
     "lodash.kebabcase": "^4.1.1",
     "mkdirp": "^0.5.1",
+    "node-fetch": "^2.0.0",
     "p-limit": "^1.2.0",
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.1",

--- a/utils/file-parser.js
+++ b/utils/file-parser.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const yaml = require('js-yaml');
 const Joi = require('joi');
 const util = require('util');
+const fetch = require('node-fetch');
+const { URL } = require('url');
 const access = util.promisify(fs.access);
 const readFile = util.promisify(fs.readFile);
 
@@ -12,8 +14,13 @@ const schema = Joi.object().keys({
     width: Joi.number(),
     pixelRatio: Joi.number().optional().default(1)
   })),
+  sitemap: Joi.object().keys({
+    path: Joi.string().required(),
+    ignore: Joi.array().items(Joi.string())
+  }).optional(),
   urls: Joi.array().items(Joi.object().keys({
     url: Joi.string().required(),
+    name: Joi.string().optional(),
     css: Joi.string().optional()
   }))
 });
@@ -34,6 +41,25 @@ module.exports = async (file, def) => {
       const data = await readFile(file, 'utf-8');
       const yamlParse = yaml.safeLoad(data);
       const parsed = Object.assign({}, yamlParse, defaults);
+
+      if (parsed.sitemap) {
+        console.log('URLs are coming from sitemap at "%s"', parsed.sitemap.path);
+        const sitemapUrl = new URL(parsed.sitemap.path, parsed.domain);
+        const response = await fetch(sitemapUrl);
+        const sitemap = await response.json();
+        const currentUrls = parsed.urls.map(u => u.url);
+
+        sitemap.forEach(url => {
+          if (currentUrls.indexOf(url) < 0) {
+            parsed.urls.push({ url });
+          }
+        });
+
+        if (parsed.sitemap.ignore) {
+          const regexes = parsed.sitemap.ignore.map(r => new RegExp(r));
+          parsed.urls = parsed.urls.filter(o => !regexes.some(r => r.exec(o.url)));
+        }
+      }
 
       return Joi.validate(parsed, schema);
     }

--- a/utils/url-process.js
+++ b/utils/url-process.js
@@ -5,6 +5,7 @@ const { URL } = require('url');
 const mkdirp = require('mkdirp');
 const util = require('util');
 const fs = require('fs');
+const chalk = require('chalk');
 
 const config = require('dotenv-safe').load({
   allowEmptyValues: true
@@ -28,7 +29,7 @@ const request = async function(browser, path, setting) {
     }
 
     if (imageExists) {
-      console.log(`Existent image for "${setting.url}" on ${setting.device}. Skipping.`);
+      console.log(`Existent image for "${setting.url}" on ${setting.device}. ${chalk.yellow('Skipping')}.`);
       return Promise.resolve();
     }
 
@@ -57,7 +58,8 @@ const request = async function(browser, path, setting) {
     return page.close();
   } catch (e) {
     console.log(`Error while parsing "${setting.url}"`, e);
-    return Promise.reject(e);
+    // Resolving so we move on
+    return Promise.resolve(e);
   }
 };
 
@@ -83,7 +85,14 @@ module.exports = async (settings) => {
   Object.keys(settings.devices).forEach(device => {
     settings.urls.forEach(object => {
       const finalUrl = new URL(object.url, settings.domain).toString();
-      const name = object.url === '/' ? 'home' : kebabCase(object.url.toLowerCase());
+      let name = '';
+
+      if (object.name) {
+        name = object.name;
+      } else {
+        name = object.url === '/' ? 'home' : kebabCase(object.url.toLowerCase());
+      }
+
       const url = Object.assign({}, object, {
         url: finalUrl,
         pathName: name,


### PR DESCRIPTION
## Sitemap support

Setting a sitemap object on the .yaml allows fetching URLs from a given endpoint.
An optional `ignore` array can be provided to be able to exclude certain URLs.

## Name tags

Allows for tags to be defined on the URL object so they can be repeated. Useful in conjunction with CSS to produce different page layouts.

### Misc

Ensure that errors on a given URL can't leave the process hung forever.